### PR TITLE
Add a ponyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,33 @@
 
 [![browser support][testling-svg]][testling-url]
 
-A spec-compliant `Array.prototype.includes` shim/polyfill/replacement that works as far down as ES3.
-Invoke its "shim" method to shim `Array.prototype.includes` if it is unavailable.
+A spec-compliant `Array.prototype.includes` shim/ponyfill/polyfill/replacement that works as far down as ES3.
+
+## Usage
+
+Require `'array-includes/ponyfill'` to use the native method if available, and otherwise a spec-compliant shim:
+
+```js
+var includes = require('array-includes/ponyfill');
+includes([NaN], NaN);
+//» true
+```
+
+Require `'array-includes'` to use the spec-compliant shim:
+
+```js
+var includes = require('array-includes');
+includes([NaN], NaN);
+//» true
+```
+
+Invoke the `shim` method if you [really want](https://github.com/sindresorhus/object-assign/issues/10#issuecomment-65065859) a classical polyfill:
+
+```js
+require('array-includes').shim();
+[NaN].includes(NaN);
+//» true
+```
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
 	"license": "MIT",
 	"main": "index.js",
 	"scripts": {
-		"test": "npm run lint && npm run test:shimmed && npm run test:module && npm run security",
+		"test": "npm run lint && npm run test:shimmed && npm run test:module && npm run test:ponyfill-native && npm run test:ponyfill-shim && npm run security",
 		"test:shimmed": "node test/shimmed.js",
 		"test:module": "node test/index.js",
+		"test:ponyfill-native": "node test/ponyfill-native.js",
+		"test:ponyfill-shim": "node test/ponyfill-shim.js",
 		"coverage": "covert test/*.js",
 		"coverage:quiet": "covert test/*.js --quiet",
 		"lint": "npm run jscs && npm run eslint",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"ES7",
 		"shim",
 		"polyfill",
+		"ponyfill",
 		"contains",
 		"Array.prototype.contains"
 	],

--- a/ponyfill.js
+++ b/ponyfill.js
@@ -1,0 +1,9 @@
+module.exports = (
+  typeof Array.prototype.includes === 'function' ?
+  function (array) {
+    return Array.prototype.includes.apply(array,
+      Array.prototype.slice.call(arguments, 1)
+    );
+  } :
+  require('./index')
+);

--- a/test/ponyfill-native.js
+++ b/test/ponyfill-native.js
@@ -1,0 +1,17 @@
+var test = require('tape');
+
+// Mock `Array.prototype.includes`.
+var FAKE = {};
+/* eslint-disable no-extend-native */
+Array.prototype.includes = function () { return FAKE; };
+/* eslint-enable no-extend-native */
+
+test('ponyfill (native method available)', function (t) {
+  t.equal(
+    require('../ponyfill')([NaN], NaN),
+    FAKE,
+    'uses the native method'
+  );
+
+  t.end();
+});

--- a/test/ponyfill-shim.js
+++ b/test/ponyfill-shim.js
@@ -1,0 +1,16 @@
+var test = require('tape');
+
+// Make sure `Array.prototype.includes` is not available.
+/* eslint-disable no-extend-native */
+delete Array.prototype.includes;
+/* eslint-enable no-extend-native */
+
+test('ponyfill (native method not available)', function (t) {
+  t.equal(
+    require('../ponyfill')([NaN], NaN),
+    true,
+    'uses the shim'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
“ponyfill” is a polyfill which uses the native method when available and doesn’t modify global objects. @sindresorhus [coined the term together](https://github.com/sindresorhus/object-assign) – [and others followed](https://www.npmjs.com/browse/keyword/ponyfill).

More reading:
- https://github.com/sindresorhus/object-assign/issues/10
- http://kikobeats.com/polyfill-ponyfill-and-prollyfill/

![image](https://cloud.githubusercontent.com/assets/4624660/8805168/1cce7a86-2fd0-11e5-8785-2510e40c19b2.png)
