### PR TITLE
syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,16 @@ Because `Array.prototype.includes` depends on a receiver (the “this” value),
 ```js
 var includes = require('array-includes');
 var assert = require('assert');
-var arr = {
+var arr = [
 	1,
 	'foo',
 	NaN,
 	-0
-};
+];
+
 assert.equal(arr.indexOf(0) > -1, true);
 assert.equal(arr.indexOf(-0) > -1, true);
-assert.equal(includes(arr, 0), false);
+assert.equal(includes(arr, 0), true);
 assert.equal(includes(arr, -0), true);
 
 assert.equal(arr.indexOf(NaN) > -1, false);
@@ -46,7 +47,7 @@ var assert = require('assert');
 /* when Array#includes is not present */
 delete Array.prototype.includes;
 var shimmedIncludes = includes.shim();
-assert.equal(shimmedIncludes, includes);
+assert.equal(typeof shimmedIncludes, typeof includes);
 assert.deepEqual(arr.includes('foo', 1), includes(arr, 'foo', 1));
 ```
 


### PR DESCRIPTION
It seems that `includes(arr, 0)` returns `true` unexpectedly.
