### PR TITLE
Whitelist distribution files when publishing NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
 	"description": "An ES7/ES2016 spec-compliant `Array.prototype.includes` shim/polyfill/replacement that works as far down as ES3.",
 	"license": "MIT",
 	"main": "index.js",
+	"files": [
+		"index.js",
+		"implementation.js",
+		"polyfill.js",
+		"shim.js",
+		"auto.js"
+	],
 	"scripts": {
 		"pretest": "npm run --silent lint && evalmd README.md",
 		"test": "npm run --silent tests-only",


### PR DESCRIPTION
I noticed that `array-includes` contains the `test` folder, `.travis.yml`, and a few other files in the distributed NPM package.

![image](https://user-images.githubusercontent.com/13087421/58371929-da65fa80-7f48-11e9-8afe-3264a3eab22b.png)

In the spirit of keeping module size small, this PR whitelists `index.js`, `implementation.js`, `polyfill.js`, `shim.js`, and `auto.js`

Cheers :) 